### PR TITLE
updated docker-compose.yml for M1

### DIFF
--- a/demo/teamserver_k8s/mysql/docker-compose.yml
+++ b/demo/teamserver_k8s/mysql/docker-compose.yml
@@ -4,6 +4,7 @@ services:
  db:
    image: mysql:8.0.28
    container_name: mysql
+   platform: linux/x86_64
    restart: always
    environment:
      MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
updated docker-compose.yml to force using linux/x86_64 image for M1 Mac Docker Desktop environment

docker-compose.ymlを修正して linux/x86_64のイメージを指定するようにしました。M1のDocker DesktopだとデフォルトでARM64のイメージを取得する挙動のようです。