### PR TITLE
update docker-compose.yml for M1

### DIFF
--- a/demo/teamserver_k8s/mysql/docker-compose.yml
+++ b/demo/teamserver_k8s/mysql/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
  db:
    image: mysql:8.0.28
+   platform: linux/x86_64
    container_name: mysql
    restart: always
    environment:
@@ -12,7 +13,7 @@ services:
      MYSQL_PASSWORD: password
      TZ: 'Asia/Tokyo'
 
-   command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --log_bin_trust_function_creators=1
+   command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --log_bin_trust_function_creators=1 --innodb_use_native_aio=0
    volumes:
      - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
      - ./data:/var/lib/mysql


### PR DESCRIPTION
1. imageをlinux/x86_64指定としました。
M1 MacのDockerDesktopではarm64のイメージを持ってこようとして失敗します。
2.   --innodb_use_native_aio=0としました。
Linux Native AIO interfaceが同様にM1 MacのDockerDesktopには無いようです。